### PR TITLE
CRM-11331 action links on page 2 not working

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3733,7 +3733,7 @@ civicrm_relationship.start_date > {$today}
    * @param boolean  $count    is this a count only query ?
    * @param boolean  $includeContactIds should we include contact ids?
    * @param boolean  $sortByChar if true returns the distinct array of first characters for search results
-   * @param boolean  $groupContacts if true, use a single mysql group_concat statement to get the contact ids
+   * @param boolean  $groupContacts if true, return only the contact ids
    * @param boolean  $returnQuery   should we return the query as a string
    * @param string   $additionalWhereClause if the caller wants to further restrict the search (used for components)
    * @param string   $additionalFromClause should be clause with proper joins, effective to reduce where clause load.

--- a/CRM/Contact/Form/Search/Custom/ActivitySearch.php
+++ b/CRM/Contact/Form/Search/Custom/ActivitySearch.php
@@ -145,11 +145,11 @@ class CRM_Contact_Form_Search_Custom_ActivitySearch implements CRM_Contact_Form_
    * Construct the search query
    */
   function all($offset = 0, $rowcount = 0, $sort = NULL,
-    $includeContactIDs = FALSE, $onlyIDs = FALSE
+    $includeContactIDs = FALSE, $justIDs = FALSE
   ) {
 
     // SELECT clause must include contact_id as an alias for civicrm_contact.id
-    if ($onlyIDs) {
+    if ($justIDs) {
       $select = 'contact_a.id as contact_id';
     }
     else {
@@ -195,7 +195,7 @@ class CRM_Contact_Form_Search_Custom_ActivitySearch implements CRM_Contact_Form_
     $sql = " SELECT $select FROM   $from $where ";
 
     //no need to add order when only contact Ids.
-    if (!$onlyIDs) {
+    if (!$justIDs) {
       // Define ORDER BY for query in $sort, with default value
       if (!empty($sort)) {
         if (is_string($sort)) {
@@ -226,19 +226,19 @@ class CRM_Contact_Form_Search_Custom_ActivitySearch implements CRM_Contact_Form_
   function from() {
     return "
         civicrm_contact contact_a
-            JOIN civicrm_activity activity 
+            JOIN civicrm_activity activity
                  ON contact_a.id = activity.source_contact_id
-            JOIN civicrm_option_value ov1 
+            JOIN civicrm_option_value ov1
                  ON activity.activity_type_id = ov1.value AND ov1.option_group_id = 2
-            JOIN civicrm_option_value ov2 
+            JOIN civicrm_option_value ov2
                  ON activity.status_id = ov2.value AND ov2.option_group_id = {$this->_groupId}
-            JOIN civicrm_contact contact_b 
+            JOIN civicrm_contact contact_b
                  ON activity.source_contact_id = contact_b.id
-            LEFT JOIN civicrm_case_activity cca 
+            LEFT JOIN civicrm_case_activity cca
                  ON activity.id = cca.activity_id
-            LEFT JOIN civicrm_activity_assignment assignment 
+            LEFT JOIN civicrm_activity_assignment assignment
                  ON activity.id = assignment.activity_id
-            LEFT JOIN civicrm_contact contact_c 
+            LEFT JOIN civicrm_contact contact_c
                  ON assignment.assignee_contact_id = contact_c.id ";
   }
 
@@ -254,8 +254,8 @@ class CRM_Contact_Form_Search_Custom_ActivitySearch implements CRM_Contact_Form_
     if (!empty($contactname)) {
       $dao         = new CRM_Core_DAO();
       $contactname = $dao->escape($contactname);
-      $clauses[]   = "(contact_a.sort_name LIKE '%{$contactname}%' OR 
-                           contact_b.sort_name LIKE '%{$contactname}%' OR 
+      $clauses[]   = "(contact_a.sort_name LIKE '%{$contactname}%' OR
+                           contact_b.sort_name LIKE '%{$contactname}%' OR
                            contact_c.display_name LIKE '%{$contactname}%')";
     }
 
@@ -316,9 +316,9 @@ class CRM_Contact_Form_Search_Custom_ActivitySearch implements CRM_Contact_Form_
     return implode(' AND ', $clauses);
   }
 
-  /* 
-     * Functions below generally don't need to be modified
-     */
+  /*
+   * Functions below generally don't need to be modified
+   */
   function count() {
     $sql = $this->all();
 

--- a/CRM/Contact/Form/Search/Custom/Base.php
+++ b/CRM/Contact/Form/Search/Custom/Base.php
@@ -38,34 +38,41 @@ class CRM_Contact_Form_Search_Custom_Base {
 
   protected $_columns;
 
-  protected $_stateID; function __construct(&$formValues) {
+  protected $_stateID;
+
+  function __construct(&$formValues) {
     $this->_formValues = &$formValues;
   }
 
   function count() {
-    return CRM_Core_DAO::singleValueQuery($this->sql('count(distinct contact_a.id) as total'),
-      CRM_Core_DAO::$_nullArray
-    );
+    return CRM_Core_DAO::singleValueQuery($this->sql('count(distinct contact_a.id) as total'));
   }
 
   function summary() {
     return NULL;
   }
 
-  function contactIDs($offset = 0, $rowcount = 0, $sort = NULL) {
-    $sql = $this->sql('contact_a.id as contact_id',
-      $offset, $rowcount, $sort
+  function contactIDs($offset = 0, $rowcount = 0, $sort = NULL, $returnSQL = FALSE) {
+    $sql = $this->sql(
+      'contact_a.id as contact_id',
+      $offset,
+      $rowcount,
+      $sort
     );
     $this->validateUserSQL($sql);
 
-    return CRM_Core_DAO::composeQuery($sql,
-      CRM_Core_DAO::$_nullArray,
-      TRUE
-    );
+    if ($returnSQL) {
+      return $sql;
+    }
+
+    return CRM_Core_DAO::composeQuery($sql);
   }
 
-  function sql($selectClause,
-    $offset            = 0, $rowcount = 0, $sort = NULL,
+  function sql(
+    $selectClause,
+    $offset   = 0,
+    $rowcount = 0,
+    $sort = NULL,
     $includeContactIDs = FALSE,
     $groupBy           = NULL
   ) {
@@ -98,8 +105,7 @@ class CRM_Contact_Form_Search_Custom_Base {
     return $this->_columns;
   }
 
-  static
-  function includeContactIDs(&$sql, &$formValues) {
+  static function includeContactIDs(&$sql, &$formValues) {
     $contactIDs = array();
     foreach ($formValues as $id => $value) {
       if ($value &&
@@ -115,9 +121,7 @@ class CRM_Contact_Form_Search_Custom_Base {
     }
   }
 
-  function addSortOffset(&$sql,
-    $offset, $rowcount, $sort
-  ) {
+  function addSortOffset(&$sql, $offset, $rowcount, $sort) {
     if (!empty($sort)) {
       if (is_string($sort)) {
         $sql .= " ORDER BY $sort ";

--- a/CRM/Contact/Form/Search/Custom/Basic.php
+++ b/CRM/Contact/Form/Search/Custom/Basic.php
@@ -126,12 +126,22 @@ class CRM_Contact_Form_Search_Custom_Basic extends CRM_Contact_Form_Search_Custo
     return $this->_query->searchQuery(0, 0, NULL, TRUE);
   }
 
-  function all($offset = 0, $rowCount = 0, $sort = NULL,
-    $includeContactIDs = FALSE
+  function all(
+    $offset = 0,
+    $rowCount = 0,
+    $sort = NULL,
+    $includeContactIDs = FALSE,
+    $justIDs = FALSE
   ) {
-    return $this->_query->searchQuery($offset, $rowCount, $sort,
-      FALSE, $includeContactIDs,
-      FALSE, FALSE, TRUE
+    return $this->_query->searchQuery(
+      $offset,
+      $rowCount,
+      $sort,
+      FALSE,
+      $includeContactIDs,
+      FALSE,
+      $justIDs,
+      TRUE
     );
   }
 

--- a/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
+++ b/CRM/Contact/Form/Search/Custom/ContributionAggregate.php
@@ -97,12 +97,12 @@ class CRM_Contact_Form_Search_Custom_ContributionAggregate implements CRM_Contac
    * Construct the search query
    */
   function all($offset = 0, $rowcount = 0, $sort = NULL,
-    $includeContactIDs = FALSE, $onlyIDs = FALSE
+    $includeContactIDs = FALSE, $justIDs = FALSE
   ) {
 
     // SELECT clause must include contact_id as an alias for civicrm_contact.id
-    if ($onlyIDs) {
-      $select = "DISTINCT contact_a.id as contact_id";
+    if ($justIDs) {
+      $select = "contact_a.id as contact_id";
     }
     else {
       $select = "
@@ -129,7 +129,7 @@ GROUP BY contact_a.id
 $having
 ";
     //for only contact ids ignore order.
-    if (!$onlyIDs) {
+    if (!$justIDs) {
       // Define ORDER BY for query in $sort, with default value
       if (!empty($sort)) {
         if (is_string($sort)) {
@@ -213,7 +213,7 @@ civicrm_contact AS contact_a
     return implode(' AND ', $clauses);
   }
 
-  /* 
+  /*
      * Functions below generally don't need to be modified
      */
   function count() {

--- a/CRM/Contact/Form/Search/Custom/DateAdded.php
+++ b/CRM/Contact/Form/Search/Custom/DateAdded.php
@@ -99,7 +99,7 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
   }
 
   function all($offset = 0, $rowcount = 0, $sort = NULL,
-    $includeContactIDs = FALSE
+    $includeContactIDs = FALSE, $justIDs = FALSE
   ) {
 
     $this->_includeGroups = CRM_Utils_Array::value('includeGroups', $this->_formValues, array());
@@ -119,10 +119,14 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
       $this->_groups = TRUE;
     }
 
-    $selectClause = "contact_a.id  as contact_id,
-                         contact_a.contact_type as contact_type,
-                         contact_a.sort_name    as sort_name,
-                         d.date_added           as date_added";
+    if ($justIDs) {
+      $select = "contact_a.id as contact_id";
+    else {
+      $selectClause = "contact_a.id  as contact_id,
+                       contact_a.contact_type as contact_type,
+                       contact_a.sort_name    as sort_name,
+                      d.date_added           as date_added";
+    }
 
     $groupBy = " GROUP BY contact_id ";
     return $this->sql($selectClause,
@@ -164,7 +168,7 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
           GROUP BY
               civicrm_contact.id
           HAVING
-              date_added >= '$startDate' 
+              date_added >= '$startDate'
               $endDateFix";
 
     if ($this->_debug > 0) {
@@ -215,8 +219,8 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
         $excludeGroup = "INSERT INTO  Xg_{$this->_tableName} ( contact_id )
                   SELECT  DISTINCT civicrm_group_contact.contact_id
                   FROM civicrm_group_contact, dates_{$this->_tableName} AS d
-                  WHERE 
-                     d.id = civicrm_group_contact.contact_id AND 
+                  WHERE
+                     d.id = civicrm_group_contact.contact_id AND
                      civicrm_group_contact.status = 'Added' AND
                      civicrm_group_contact.group_id IN( {$xGroups})";
 
@@ -229,8 +233,8 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
 
             $smartSql = CRM_Contact_BAO_SavedSearch::contactIDsSQL($ssId);
 
-            $smartSql = $smartSql . " AND contact_a.id NOT IN ( 
-                              SELECT contact_id FROM civicrm_group_contact 
+            $smartSql = $smartSql . " AND contact_a.id NOT IN (
+                              SELECT contact_id FROM civicrm_group_contact
                               WHERE civicrm_group_contact.group_id = {$values} AND civicrm_group_contact.status = 'Removed')";
 
             $smartGroupQuery = " INSERT IGNORE INTO Xg_{$this->_tableName}(contact_id) $smartSql";
@@ -268,7 +272,7 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
         $includeGroup .= " LEFT JOIN        Xg_{$this->_tableName}
                                           ON        d.id = Xg_{$this->_tableName}.contact_id";
       }
-      $includeGroup .= " WHERE           
+      $includeGroup .= " WHERE
                                      civicrm_group_contact.status = 'Added'  AND
                                      civicrm_group_contact.group_id IN($iGroups)";
 
@@ -297,7 +301,7 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
                                    SELECT id AS contact_id
                                    FROM dates_{$this->_tableName} )";
 
-          $smartSql .= " AND contact_a.id NOT IN ( 
+          $smartSql .= " AND contact_a.id NOT IN (
                                    SELECT contact_id FROM civicrm_group_contact
                                    WHERE civicrm_group_contact.group_id = {$values} AND civicrm_group_contact.status = 'Removed')";
 
@@ -307,7 +311,7 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
           }
 
           $smartGroupQuery = " INSERT IGNORE INTO
-                        Ig_{$this->_tableName}(contact_id) 
+                        Ig_{$this->_tableName}(contact_id)
                         $smartSql";
 
           CRM_Core_DAO::executeQuery($smartGroupQuery, CRM_Core_DAO::$_nullArray);
@@ -319,7 +323,7 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
           $insertGroupNameQuery = "UPDATE IGNORE Ig_{$this->_tableName}
                         SET group_names = (SELECT title FROM civicrm_group
                             WHERE civicrm_group.id = $values)
-                        WHERE Ig_{$this->_tableName}.contact_id IS NOT NULL 
+                        WHERE Ig_{$this->_tableName}.contact_id IS NOT NULL
                             AND Ig_{$this->_tableName}.group_names IS NULL";
           CRM_Core_DAO::executeQuery($insertGroupNameQuery, CRM_Core_DAO::$_nullArray);
           if ($this->_debug > 0) {

--- a/CRM/Contact/Form/Search/Custom/EmployerListing.php
+++ b/CRM/Contact/Form/Search/Custom/EmployerListing.php
@@ -34,7 +34,9 @@
  */
 class CRM_Contact_Form_Search_Custom_EmployerListing implements CRM_Contact_Form_Search_Interface {
 
-  protected $_formValues; function __construct(&$formValues) {
+  protected $_formValues;
+
+  function __construct(&$formValues) {
     $this->_formValues = $formValues;
 
     /**
@@ -95,17 +97,20 @@ class CRM_Contact_Form_Search_Custom_EmployerListing implements CRM_Contact_Form
    * Construct the search query
    */
   function all($offset = 0, $rowcount = 0, $sort = NULL,
-    $includeContactIDs = FALSE
+    $includeContactIDs = FALSE, $justIDs = FALSE
   ) {
-
-    // SELECT clause must include contact_id as an alias for civicrm_contact.id
-    $select = "
+    if ($justIDs) {
+      $select = "cInd.id as contact_id";
+    }
+    else {
+      $select = "
             DISTINCT cInd.id as contact_id,
             cInd.sort_name as sort_name,
             indSP.name as indState,
             cEmp.sort_name as employer,
             empSP.name as empState
             ";
+    }
 
     $from = $this->from();
 
@@ -153,7 +158,7 @@ class CRM_Contact_Form_Search_Custom_EmployerListing implements CRM_Contact_Form
             civicrm_contact cInd
             LEFT JOIN civicrm_address indAddress ON ( indAddress.contact_id = cInd.id AND
             indAddress.is_primary       = 1 )
-            LEFT JOIN civicrm_state_province indSP ON indSP.id = indAddress.state_province_id,           
+            LEFT JOIN civicrm_state_province indSP ON indSP.id = indAddress.state_province_id,
             civicrm_contact cEmp
             LEFT JOIN civicrm_address empAddress ON ( empAddress.contact_id = cEmp.id AND
             empAddress.is_primary       = 1 )
@@ -217,7 +222,7 @@ class CRM_Contact_Form_Search_Custom_EmployerListing implements CRM_Contact_Form
     return implode(' AND ', $clauses);
   }
 
-  /* 
+  /*
      * Functions below generally don't need to be modified
      */
   function count() {

--- a/CRM/Contact/Form/Search/Custom/EventAggregate.php
+++ b/CRM/Contact/Form/Search/Custom/EventAggregate.php
@@ -98,7 +98,7 @@ class CRM_Contact_Form_Search_Custom_EventAggregate extends CRM_Contact_Form_Sea
    * Construct the search query
    */
   function all($offset = 0, $rowcount = 0, $sort = NULL,
-    $includeContactIDs = FALSE
+    $includeContactIDs = FALSE, $justIDs = FALSE
   ) {
     // SELECT clause must include contact_id as an alias for civicrm_contact.id if you are going to use "tasks" like export etc.
     $select = "civicrm_participant.event_id as event_id,
@@ -117,7 +117,7 @@ class CRM_Contact_Form_Search_Custom_EventAggregate extends CRM_Contact_Form_Sea
       $this->_formValues
     );
     if ($onLine) {
-      $from .= "         
+      $from .= "
         inner join civicrm_entity_financial_trxn
         on (civicrm_entity_financial_trxn.entity_id = civicrm_participant_payment.contribution_id and civicrm_entity_financial_trxn.entity_table='civicrm_contribution')";
     }
@@ -174,13 +174,13 @@ class CRM_Contact_Form_Search_Custom_EventAggregate extends CRM_Contact_Form_Sea
         civicrm_participant_payment
         left join civicrm_participant
         on civicrm_participant_payment.participant_id=civicrm_participant.id
-        
+
         left join civicrm_event on
         civicrm_participant.event_id = civicrm_event.id
-        
-        left join civicrm_contribution 
+
+        left join civicrm_contribution
         on civicrm_contribution.id = civicrm_participant_payment.contribution_id
-        
+
         left join civicrm_option_value on
         ( civicrm_option_value.value = civicrm_event.event_type_id AND civicrm_option_value.option_group_id = 14)";
   }
@@ -252,7 +252,7 @@ class CRM_Contact_Form_Search_Custom_EventAggregate extends CRM_Contact_Form_Sea
       $this->_formValues
     );
     if ($onLine) {
-      $from .= "         
+      $from .= "
         inner join civicrm_entity_financial_trxn
         on (civicrm_entity_financial_trxn.entity_id = civicrm_participant_payment.contribution_id and civicrm_entity_financial_trxn.entity_table='civicrm_contribution')";
     }
@@ -280,7 +280,7 @@ class CRM_Contact_Form_Search_Custom_EventAggregate extends CRM_Contact_Form_Sea
     return $totals;
   }
 
-  /* 
+  /*
      * Functions below generally don't need to be modified
      */
   function count() {

--- a/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/CRM/Contact/Form/Search/Custom/FullText.php
@@ -205,7 +205,7 @@ CREATE TEMPORARY TABLE {$this->_tableName} (
 CREATE TEMPORARY TABLE {$this->_entityIDTableName} (
   id int unsigned NOT NULL AUTO_INCREMENT,
   entity_id int unsigned NOT NULL,
-  
+
   UNIQUE INDEX unique_entity_id ( entity_id ),
   PRIMARY KEY ( id )
 ) ENGINE=HEAP DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci
@@ -288,7 +288,7 @@ CREATE TEMPORARY TABLE {$this->_entityIDTableName} (
     $sql = "
 DELETE     t.*
 FROM       {$this->_tableName} t
-WHERE      NOT EXISTS ( SELECT c.id 
+WHERE      NOT EXISTS ( SELECT c.id
                         FROM civicrm_acl_contact_cache c
                         WHERE c.user_id = %1 AND t.contact_id = c.contact_id )
 ";
@@ -298,7 +298,7 @@ WHERE      NOT EXISTS ( SELECT c.id
 DELETE     t.*
 FROM       {$this->_tableName} t
 WHERE      t.table_name = 'Activity' AND
-           NOT EXISTS ( SELECT c.id 
+           NOT EXISTS ( SELECT c.id
                         FROM civicrm_acl_contact_cache c
                         WHERE c.user_id = %1 AND ( t.target_contact_id = c.contact_id OR t.target_contact_id IS NULL ) )
 ";
@@ -308,7 +308,7 @@ WHERE      t.table_name = 'Activity' AND
 DELETE     t.*
 FROM       {$this->_tableName} t
 WHERE      t.table_name = 'Activity' AND
-           NOT EXISTS ( SELECT c.id 
+           NOT EXISTS ( SELECT c.id
                         FROM civicrm_acl_contact_cache c
                         WHERE c.user_id = %1 AND ( t.assignee_contact_id = c.contact_id OR t.assignee_contact_id IS NULL ) )
 ";
@@ -463,14 +463,14 @@ AND     {$tableValues['id']} IS NOT NULL
     $contactSQL = array();
 
     $contactSQL[] = "
-SELECT     distinct ca.id 
+SELECT     distinct ca.id
 FROM       civicrm_activity ca
 INNER JOIN civicrm_contact c ON ca.source_contact_id = c.id
 LEFT JOIN  civicrm_email e ON e.contact_id = c.id
 LEFT JOIN  civicrm_option_group og ON og.name = 'activity_type'
-LEFT JOIN  civicrm_option_value ov ON ( ov.option_group_id = og.id ) 
+LEFT JOIN  civicrm_option_value ov ON ( ov.option_group_id = og.id )
 WHERE      (c.sort_name LIKE {$this->_text} OR c.display_name LIKE {$this->_text}) OR
-           ( e.email LIKE {$this->_text}    AND 
+           ( e.email LIKE {$this->_text}    AND
              ca.activity_type_id = ov.value AND
              ov.name IN ('Inbound Email', 'Email') )
 AND (ca.is_deleted = 0 OR ca.is_deleted IS NULL OR
@@ -478,15 +478,15 @@ AND (ca.is_deleted = 0 OR ca.is_deleted IS NULL OR
 ";
 
     $contactSQL[] = "
-SELECT     distinct ca.id 
+SELECT     distinct ca.id
 FROM       civicrm_activity ca
 INNER JOIN civicrm_activity_target cat ON cat.activity_id = ca.id
 INNER JOIN civicrm_contact c ON cat.target_contact_id = c.id
 LEFT  JOIN civicrm_email e ON cat.target_contact_id = e.contact_id
 LEFT  JOIN civicrm_option_group og ON og.name = 'activity_type'
-LEFT  JOIN civicrm_option_value ov ON ( ov.option_group_id = og.id ) 
+LEFT  JOIN civicrm_option_value ov ON ( ov.option_group_id = og.id )
 WHERE      (c.sort_name LIKE {$this->_text} OR c.display_name LIKE {$this->_text}) OR
-           ( e.email LIKE {$this->_text}    AND 
+           ( e.email LIKE {$this->_text}    AND
              ca.activity_type_id = ov.value AND
              ov.name IN ('Inbound Email', 'Email') )
 AND (ca.is_deleted = 0 OR ca.is_deleted IS NULL OR
@@ -494,7 +494,7 @@ AND (ca.is_deleted = 0 OR ca.is_deleted IS NULL OR
 ";
 
     $contactSQL[] = "
-SELECT     distinct ca.id 
+SELECT     distinct ca.id
 FROM       civicrm_activity ca
 INNER JOIN civicrm_activity_assignment caa ON caa.activity_id = ca.id
 INNER JOIN civicrm_contact c ON caa.assignee_contact_id = c.id
@@ -539,7 +539,7 @@ AND (ca.is_deleted = 0 OR ca.is_deleted IS NULL OR
 INSERT INTO {$this->_tableName}
 ( table_name, contact_id, sort_name, case_id, case_start_date, case_end_date, case_is_deleted )
 SELECT SQL_CALC_FOUND_ROWS 'Case', c.id, c.sort_name, cc.id, DATE(cc.start_date), DATE(cc.end_date), cc.is_deleted
-FROM      civicrm_case cc 
+FROM      civicrm_case cc
 LEFT JOIN civicrm_case_contact ccc ON cc.id = ccc.case_id
 LEFT JOIN civicrm_contact c ON ccc.contact_id = c.id
 WHERE     (c.sort_name LIKE {$this->_text} OR c.display_name LIKE {$this->_text})
@@ -556,7 +556,7 @@ WHERE     (c.sort_name LIKE {$this->_text} OR c.display_name LIKE {$this->_text}
 INSERT INTO {$this->_tableName}
   ( table_name, contact_id, sort_name, case_id, case_start_date, case_end_date, case_is_deleted )
 SELECT SQL_CALC_FOUND_ROWS 'Case', c.id, c.sort_name, cc.id, DATE(cc.start_date), DATE(cc.end_date), cc.is_deleted
-FROM      civicrm_case cc 
+FROM      civicrm_case cc
 LEFT JOIN civicrm_case_contact ccc ON cc.id = ccc.case_id
 LEFT JOIN civicrm_contact c ON ccc.contact_id = c.id
 WHERE     cc.id = {$this->_textID}
@@ -587,7 +587,7 @@ WHERE     cc.id = {$this->_textID}
   function fillContributionIDs() {
     $contactSQL = array();
     $contactSQL[] = "
-SELECT     distinct cc.id 
+SELECT     distinct cc.id
 FROM       civicrm_contribution cc
 INNER JOIN civicrm_contact c ON cc.contact_id = c.id
 WHERE      (c.sort_name LIKE {$this->_text} OR
@@ -634,7 +634,7 @@ WHERE      (c.sort_name LIKE {$this->_text} OR
   function fillParticipantIDs() {
     $contactSQL = array();
     $contactSQL[] = "
-SELECT     distinct cp.id 
+SELECT     distinct cp.id
 FROM       civicrm_participant cp
 INNER JOIN civicrm_contact c ON cp.contact_id = c.id
 WHERE      (c.sort_name LIKE {$this->_text} OR c.display_name LIKE {$this->_text})
@@ -678,7 +678,7 @@ WHERE      (c.sort_name LIKE {$this->_text} OR c.display_name LIKE {$this->_text
   function fillMembershipIDs() {
     $contactSQL = array();
     $contactSQL[] = "
-SELECT     distinct cm.id 
+SELECT     distinct cm.id
 FROM       civicrm_membership cm
 INNER JOIN civicrm_contact c ON cm.contact_id = c.id
 WHERE      (c.sort_name LIKE {$this->_text} OR c.display_name LIKE {$this->_text})
@@ -823,18 +823,24 @@ WHERE      (c.sort_name LIKE {$this->_text} OR c.display_name LIKE {$this->_text
   }
 
   function all($offset = 0, $rowcount = 0, $sort = NULL,
-    $includeContactIDs = FALSE
+    $includeContactIDs = FALSE, $justIDs = FALSE
   ) {
     $this->initialize();
 
+    if ($justIDs) {
+      $select = "contact_a.contact_id as contact_id";
+    }
+    else {
+      $select = "
+      contact_a.contact_id   as contact_id  ,
+      contact_a.sort_name as sort_name
+    ";
+    }
     $sql = "
-SELECT 
-  contact_a.contact_id   as contact_id  ,
-  contact_a.sort_name as sort_name
-FROM
-  {$this->_tableName} contact_a
-{$this->_limitRowClause}
-";
+    SELECT $select
+    FROM   {$this->_tableName} contact_a
+           {$this->_limitRowClause}
+    ";
     return $sql;
   }
 
@@ -883,7 +889,7 @@ INNER JOIN civicrm_contact c ON ct.entity_id = c.id
       case 'Activity':
         $sql = "
 INSERT INTO {$this->_tableName}
-( table_name, activity_id, subject, details, contact_id, sort_name, assignee_contact_id, assignee_sort_name, target_contact_id, 
+( table_name, activity_id, subject, details, contact_id, sort_name, assignee_contact_id, assignee_sort_name, target_contact_id,
   target_sort_name, activity_type_id, case_id, client_id )
 SELECT    'Activity', ca.id, substr(ca.subject, 1, 50), substr(ca.details, 1, 250),
            c1.id, c1.sort_name,
@@ -909,17 +915,17 @@ WHERE (ca.is_deleted = 0 OR ca.is_deleted IS NULL)
       case 'Contribution':
         $sql = "
 INSERT INTO {$this->_tableName}
-( table_name, contact_id, sort_name, contribution_id, contribution_type, contribution_page, contribution_receive_date, 
+( table_name, contact_id, sort_name, contribution_id, contribution_type, contribution_page, contribution_receive_date,
   contribution_total_amount, contribution_trxn_Id, contribution_source, contribution_status, contribution_check_number )
-   SELECT  'Contribution', c.id, c.sort_name, cc.id, cct.name, ccp.title, cc.receive_date, 
-           cc.total_amount, cc.trxn_id, cc.source, contribution_status.label, cc.check_number 
+   SELECT  'Contribution', c.id, c.sort_name, cc.id, cct.name, ccp.title, cc.receive_date,
+           cc.total_amount, cc.trxn_id, cc.source, contribution_status.label, cc.check_number
      FROM  {$this->_entityIDTableName} ct
 INNER JOIN civicrm_contribution cc ON cc.id = ct.entity_id
 LEFT JOIN  civicrm_contact c ON cc.contact_id = c.id
 LEFT JOIN  civicrm_contribution_type cct ON cct.id = cc.contribution_type_id
-LEFT JOIN  civicrm_contribution_page ccp ON ccp.id = cc.contribution_page_id 
+LEFT JOIN  civicrm_contribution_page ccp ON ccp.id = cc.contribution_page_id
 LEFT JOIN  civicrm_option_group option_group_contributionStatus ON option_group_contributionStatus.name = 'contribution_status'
-LEFT JOIN  civicrm_option_value contribution_status ON 
+LEFT JOIN  civicrm_option_value contribution_status ON
 ( contribution_status.option_group_id = option_group_contributionStatus.id AND contribution_status.value = cc.contribution_status_id )
 {$this->_limitRowClause}
 ";
@@ -928,9 +934,9 @@ LEFT JOIN  civicrm_option_value contribution_status ON
       case 'Participant':
         $sql = "
 INSERT INTO {$this->_tableName}
-( table_name, contact_id, sort_name, participant_id, event_title, participant_fee_level, participant_fee_amount, 
+( table_name, contact_id, sort_name, participant_id, event_title, participant_fee_level, participant_fee_amount,
 participant_register_date, participant_source, participant_status, participant_role )
-   SELECT  'Participant', c.id, c.sort_name, cp.id, ce.title, cp.fee_level, cp.fee_amount, cp.register_date, cp.source, 
+   SELECT  'Participant', c.id, c.sort_name, cp.id, ce.title, cp.fee_level, cp.fee_amount, cp.register_date, cp.source,
            participantStatus.label, cp.role_id
      FROM  {$this->_entityIDTableName} ct
 INNER JOIN civicrm_participant cp ON cp.id = ct.entity_id
@@ -942,11 +948,11 @@ LEFT JOIN  civicrm_participant_status_type participantStatus ON participantStatu
         break;
 
       case 'Membership':
-        $sql = " 
+        $sql = "
 INSERT INTO {$this->_tableName}
-( table_name, contact_id, sort_name, membership_id, membership_type, membership_fee, membership_start_date, 
+( table_name, contact_id, sort_name, membership_id, membership_type, membership_fee, membership_start_date,
 membership_end_date, membership_source, membership_status )
-   SELECT  'Membership', c.id, c.sort_name, cm.id, cmt.name, cc.total_amount, cm.start_date, cm.end_date, cm.source, cms.name 
+   SELECT  'Membership', c.id, c.sort_name, cm.id, cmt.name, cc.total_amount, cm.start_date, cm.end_date, cm.source, cms.name
      FROM  {$this->_entityIDTableName} ct
 INNER JOIN civicrm_membership cm ON cm.id = ct.entity_id
 LEFT JOIN  civicrm_contact c ON cm.contact_id = c.id

--- a/CRM/Contact/Form/Search/Custom/Group.php
+++ b/CRM/Contact/Form/Search/Custom/Group.php
@@ -418,7 +418,7 @@ class CRM_Contact_Form_Search_Custom_Group extends CRM_Contact_Form_Search_Custo
                   SELECT  DISTINCT civicrm_entity_tag.entity_id
                   FROM civicrm_entity_tag, civicrm_contact
                   WHERE
-                     civicrm_entity_tag.entity_table = 'civicrm_contact' AND
+                     civicrm_contact.id = civicrm_entity_tag.entity_id AND
                      civicrm_contact.id = civicrm_entity_tag.entity_id AND
                      civicrm_entity_tag.tag_id IN( {$xTags})";
 

--- a/CRM/Contact/Form/Search/Custom/MultipleValues.php
+++ b/CRM/Contact/Form/Search/Custom/MultipleValues.php
@@ -128,7 +128,7 @@ class CRM_Contact_Form_Search_Custom_MultipleValues extends CRM_Contact_Form_Sea
   }
 
   function all($offset = 0, $rowcount = 0, $sort = NULL,
-    $includeContactIDs = FALSE
+    $includeContactIDs = FALSE, $justIDs = FALSE
   ) {
     //redirect if custom group not select in search criteria
     if (!CRM_Utils_Array::value('custom_group', $this->_formValues)) {
@@ -139,11 +139,16 @@ class CRM_Contact_Form_Search_Custom_MultipleValues extends CRM_Contact_Form_Sea
         )
       );
     }
-    $selectClause = "
-contact_a.id           as contact_id  ,
-contact_a.contact_type as contact_type,
-contact_a.sort_name    as sort_name,
-";
+    if ($justIDs) {
+      $selectClause = "contact_a.id as contact_id";
+    }
+    else {
+      $selectClause = "
+  contact_a.id           as contact_id  ,
+  contact_a.contact_type as contact_type,
+  contact_a.sort_name    as sort_name,
+  ";
+    }
 
     $customClauses = array();
     foreach ($this->_tables as $tableName => $fields) {
@@ -172,12 +177,12 @@ contact_a.sort_name    as sort_name,
 
     // This prevents duplicate rows when contacts have more than one tag any you select "any tag"
     if ($this->_tag) {
-      $from .= " LEFT JOIN civicrm_entity_tag t ON (t.entity_table='civicrm_contact' 
+      $from .= " LEFT JOIN civicrm_entity_tag t ON (t.entity_table='civicrm_contact'
                        AND contact_a.id = t.entity_id)";
     }
 
     if ($this->_group) {
-      $from .= " LEFT JOIN civicrm_group_contact cgc ON ( cgc.contact_id = contact_a.id 
+      $from .= " LEFT JOIN civicrm_group_contact cgc ON ( cgc.contact_id = contact_a.id
                        AND cgc.status = 'Added')";
     }
 

--- a/CRM/Contact/Form/Search/Custom/PostalMailing.php
+++ b/CRM/Contact/Form/Search/Custom/PostalMailing.php
@@ -57,8 +57,12 @@ class CRM_Contact_Form_Search_Custom_PostalMailing extends CRM_Contact_Form_Sear
   }
 
   function all($offset = 0, $rowcount = 0, $sort = NULL,
-    $includeContactIDs = FALSE
+    $includeContactIDs = FALSE, $justIDs = FALSE
   ) {
+    if ($justIDs) {
+      $selectClause = "contact_a.id as contact_id";
+    }
+    else {
     $selectClause = "
 DISTINCT contact_a.id  as contact_id  ,
 contact_a.contact_type  as contact_type,
@@ -66,6 +70,8 @@ contact_a.sort_name     as sort_name,
 address.street_address  as address,
 state_province.name     as state_province
 ";
+    }
+
     return $this->sql($selectClause,
       $offset, $rowcount, $sort,
       $includeContactIDs, NULL
@@ -74,7 +80,7 @@ state_province.name     as state_province
 
   function from() {
     return "
-FROM      civicrm_group_contact as cgc, 
+FROM      civicrm_group_contact as cgc,
           civicrm_contact       as contact_a
 LEFT JOIN civicrm_address address               ON (address.contact_id       = contact_a.id AND
                                                     address.is_primary       = 1 )
@@ -96,8 +102,8 @@ LEFT JOIN civicrm_state_province state_province ON  state_province.id = address.
     }
 
     $clause[] = "cgc.status   = 'Added'";
-    $clause[] = "contact_a.id = IF( EXISTS(select cr.id from civicrm_relationship cr where (cr.contact_id_a = cgc.contact_id AND (cr.relationship_type_id = 7 OR cr.relationship_type_id = 6))), 
-                                       (select cr.contact_id_b from civicrm_relationship cr where (cr.contact_id_a = cgc.contact_id AND (cr.relationship_type_id = 7 OR cr.relationship_type_id = 6))), 
+    $clause[] = "contact_a.id = IF( EXISTS(select cr.id from civicrm_relationship cr where (cr.contact_id_a = cgc.contact_id AND (cr.relationship_type_id = 7 OR cr.relationship_type_id = 6))),
+                                       (select cr.contact_id_b from civicrm_relationship cr where (cr.contact_id_a = cgc.contact_id AND (cr.relationship_type_id = 7 OR cr.relationship_type_id = 6))),
                                         cgc.contact_id )";
     $clause[] = "contact_a.contact_type IN ('Individual','Household')";
 

--- a/CRM/Contact/Form/Search/Custom/PriceSet.php
+++ b/CRM/Contact/Form/Search/Custom/PriceSet.php
@@ -113,12 +113,12 @@ WHERE  p.contact_id = c.id
 
     $sql = "
 SELECT c.id as contact_id,
-       p.id as participant_id, 
-       l.price_field_value_id as price_field_value_id, 
+       p.id as participant_id,
+       l.price_field_value_id as price_field_value_id,
        l.qty
 FROM   civicrm_contact c,
        civicrm_participant  p,
-       civicrm_line_item    l       
+       civicrm_line_item    l
 WHERE  c.id = p.contact_id
 AND    p.event_id = {$this->_eventID}
 AND    p.id = l.entity_id
@@ -252,20 +252,25 @@ AND    p.entity_id    = e.id
   }
 
   function all($offset = 0, $rowcount = 0, $sort = NULL,
-    $includeContactIDs = FALSE
+    $includeContactIDs = FALSE, $justIDs = FALSE
   ) {
-    $selectClause = "
+    if ($justIDs) {
+      $selectClause = "contact_a.id as contact_id";
+    }
+    else {
+      $selectClause = "
 contact_a.id             as contact_id  ,
 contact_a.display_name   as display_name";
 
-    foreach ($this->_columns as $dontCare => $fieldName) {
-      if (in_array($fieldName, array(
-        'contact_id',
-            'display_name',
-          ))) {
-        continue;
+      foreach ($this->_columns as $dontCare => $fieldName) {
+        if (in_array($fieldName, array(
+              'contact_id',
+              'display_name',
+            ))) {
+          continue;
+        }
+        $selectClause .= ",\ntempTable.{$fieldName} as {$fieldName}";
       }
-      $selectClause .= ",\ntempTable.{$fieldName} as {$fieldName}";
     }
 
     return $this->sql($selectClause,

--- a/CRM/Contact/Form/Search/Custom/Proximity.php
+++ b/CRM/Contact/Form/Search/Custom/Proximity.php
@@ -165,18 +165,22 @@ class CRM_Contact_Form_Search_Custom_Proximity extends CRM_Contact_Form_Search_C
   }
 
   function all($offset = 0, $rowcount = 0, $sort = NULL,
-    $includeContactIDs = FALSE
+    $includeContactIDs = FALSE, $justIDs = FALSE
   ) {
-
-    $selectClause = "
+    if ($justIDs) {
+      $selectClause = "contact_a.id as contact_id";
+    }
+    else {
+      $selectClause = "
 contact_a.id           as contact_id    ,
 contact_a.sort_name    as sort_name     ,
 address.street_address as street_address,
 address.city           as city          ,
 address.postal_code    as postal_code   ,
 state_province.name    as state_province,
-country.name           as country       
+country.name           as country
 ";
+    }
 
     return $this->sql($selectClause,
       $offset, $rowcount, $sort,

--- a/CRM/Contact/Form/Search/Custom/RandomSegment.php
+++ b/CRM/Contact/Form/Search/Custom/RandomSegment.php
@@ -113,12 +113,17 @@ class CRM_Contact_Form_Search_Custom_RandomSegment extends CRM_Contact_Form_Sear
   }
 
   function all($offset = 0, $rowcount = 0, $sort = NULL,
-    $includeContactIDs = FALSE
+    $includeContactIDs = FALSE, $justIDs = FALSE
   ) {
-    $selectClause = "contact_a.id   as contact_id,
+    if ($justIDs) {
+      $selectClause = "contact_a.id as contact_id";
+    }
+    else {
+      $selectClause = "contact_a.id   as contact_id,
                          contact_a.contact_type as contact_type,
                          contact_a.sort_name    as sort_name,
                          civicrm_email.email    as email";
+    }
 
     return $this->sql($selectClause,
       $offset, $rowcount, $sort,
@@ -168,7 +173,7 @@ class CRM_Contact_Form_Search_Custom_RandomSegment extends CRM_Contact_Form_Sear
       $excludeGroup = "INSERT INTO  Xg_{$this->_tableName} ( contact_id )
               SELECT  DISTINCT civicrm_group_contact.contact_id
               FROM civicrm_group_contact
-              WHERE 
+              WHERE
                  civicrm_group_contact.status = 'Added' AND
                  civicrm_group_contact.group_id IN ( {$xGroups} )";
 
@@ -181,8 +186,8 @@ class CRM_Contact_Form_Search_Custom_RandomSegment extends CRM_Contact_Form_Sear
 
           $smartSql = CRM_Contact_BAO_SavedSearch::contactIDsSQL($ssId);
 
-          $smartSql = $smartSql . " AND contact_a.id NOT IN ( 
-                          SELECT contact_id FROM civicrm_group_contact 
+          $smartSql = $smartSql . " AND contact_a.id NOT IN (
+                          SELECT contact_id FROM civicrm_group_contact
                           WHERE civicrm_group_contact.group_id = {$values} AND civicrm_group_contact.status = 'Removed')";
 
           $smartGroupQuery = " INSERT IGNORE INTO Xg_{$this->_tableName}(contact_id) $smartSql";
@@ -218,7 +223,7 @@ class CRM_Contact_Form_Search_Custom_RandomSegment extends CRM_Contact_Form_Sear
       $includeGroup .= " LEFT JOIN        Xg_{$this->_tableName}
                                       ON        civicrm_group_contact.contact_id = Xg_{$this->_tableName}.contact_id";
     }
-    $includeGroup .= " WHERE           
+    $includeGroup .= " WHERE
                                  civicrm_group_contact.status = 'Added'  AND
                                  civicrm_group_contact.group_id IN($iGroups)";
 
@@ -243,7 +248,7 @@ class CRM_Contact_Form_Search_Custom_RandomSegment extends CRM_Contact_Form_Sear
 
         $smartSql = CRM_Contact_BAO_SavedSearch::contactIDsSQL($ssId);
 
-        $smartSql .= " AND contact_a.id NOT IN ( 
+        $smartSql .= " AND contact_a.id NOT IN (
                                SELECT contact_id FROM civicrm_group_contact
                                WHERE civicrm_group_contact.group_id = {$values} AND civicrm_group_contact.status = 'Removed')";
 
@@ -252,14 +257,14 @@ class CRM_Contact_Form_Search_Custom_RandomSegment extends CRM_Contact_Form_Sear
           $smartSql .= " AND contact_a.id NOT IN (SELECT contact_id FROM  Xg_{$this->_tableName})";
         }
 
-        $smartGroupQuery = " INSERT IGNORE INTO Ig_{$this->_tableName}(contact_id) 
+        $smartGroupQuery = " INSERT IGNORE INTO Ig_{$this->_tableName}(contact_id)
                     $smartSql";
 
         CRM_Core_DAO::executeQuery($smartGroupQuery);
         $insertGroupNameQuery = "UPDATE IGNORE Ig_{$this->_tableName}
                     SET group_names = (SELECT title FROM civicrm_group
                         WHERE civicrm_group.id = $values)
-                    WHERE Ig_{$this->_tableName}.contact_id IS NOT NULL 
+                    WHERE Ig_{$this->_tableName}.contact_id IS NOT NULL
                         AND Ig_{$this->_tableName}.group_names IS NULL";
         CRM_Core_DAO::executeQuery($insertGroupNameQuery);
       }

--- a/CRM/Contact/Form/Search/Custom/Sample.php
+++ b/CRM/Contact/Form/Search/Custom/Sample.php
@@ -85,14 +85,20 @@ class CRM_Contact_Form_Search_Custom_Sample extends CRM_Contact_Form_Search_Cust
   }
 
   function all($offset = 0, $rowcount = 0, $sort = NULL,
-    $includeContactIDs = FALSE
+    $includeContactIDs = FALSE, $justIDs = FALSE
   ) {
-    $selectClause = "
+    if ($justIDs) {
+      $selectClause = "contact_a.id as contact_id";
+    }
+    else {
+      $selectClause = "
 contact_a.id           as contact_id  ,
 contact_a.contact_type as contact_type,
 contact_a.sort_name    as sort_name,
 state_province.name    as state_province
 ";
+    }
+
     return $this->sql($selectClause,
       $offset, $rowcount, $sort,
       $includeContactIDs, NULL

--- a/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
+++ b/CRM/Contact/Form/Search/Custom/ZipCodeRange.php
@@ -75,14 +75,19 @@ class CRM_Contact_Form_Search_Custom_ZipCodeRange extends CRM_Contact_Form_Searc
   }
 
   function all($offset = 0, $rowcount = 0, $sort = NULL,
-    $includeContactIDs = FALSE
+    $includeContactIDs = FALSE, $justIDs = FALSE
   ) {
-    $selectClause = "
+    if ($justIDs) {
+      $selectClause = "contact_a.id as contact_id";
+    }
+    else {
+      $selectClause = "
 contact_a.id           as contact_id ,
 contact_a.sort_name    as sort_name  ,
 email.email            as email   ,
 address.postal_code    as postal_code
 ";
+    }
     return $this->sql($selectClause,
       $offset, $rowcount, $sort,
       $includeContactIDs, NULL

--- a/CRM/Contact/Form/Search/Interface.php
+++ b/CRM/Contact/Form/Search/Interface.php
@@ -74,7 +74,7 @@ interface CRM_Contact_Form_Search_Interface {
    * Retrieve all the values that match the current input parameters
    * Used by the selector
    */
-  function all($offset = 0, $rowcount = 0, $sort = NULL, $includeContactIDs = FALSE);
+  function all($offset = 0, $rowcount = 0, $sort = NULL, $includeContactIDs = FALSE, $justIDs = FALSE);
 
   /**
    * The below two functions (from and where) are ONLY used if you want to

--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -228,8 +228,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
    * @access public
    *
    */
-  static
-  function &links($context = NULL, $contextMenu = NULL, $key = NULL) {
+  static function &links($context = NULL, $contextMenu = NULL, $key = NULL) {
     $extraParams = ($key) ? "&key={$key}" : NULL;
     $searchContext = ($context) ? "&context=$context" : NULL;
 
@@ -907,10 +906,18 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
     CRM_Core_BAO_PrevNextCache::deleteItem(NULL, $cacheKey, 'civicrm_contact');
 
     // lets fill up the prev next cache here, so view can scroll thru
-    $sql = $this->_query->searchQuery(0, 0, $sort,
-      FALSE, FALSE,
-      FALSE, TRUE, TRUE, NULL
-    );
+    if (is_a($this, 'CRM_Contact_Selector_Custom')) {
+      $sql = $this->_search->contactIDs(0, 0, $sort, TRUE);
+      $replaceSQL = "SELECT contact_a.id as contact_id";
+    }
+    else {
+      $sql = $this->_query->searchQuery(
+        0, 0, $sort,
+        FALSE, FALSE,
+        FALSE, TRUE, TRUE, NULL
+      );
+      $replaceSQL = "SELECT contact_a.id as id";
+    }
 
     // CRM-9096
     // due to limitations in our search query writer, the above query does not work
@@ -925,8 +932,6 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
 INSERT INTO civicrm_prevnext_cache ( entity_table, entity_id1, entity_id2, cacheKey, data )
 SELECT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', contact_a.display_name
 ";
-    $replaceSQL = "SELECT contact_a.id as id";
-
 
     $sql = str_replace($replaceSQL, $insertSQL, $sql);
 

--- a/CRM/Contact/Selector/Custom.php
+++ b/CRM/Contact/Selector/Custom.php
@@ -39,7 +39,7 @@
  * results of advanced search options.
  *
  */
-class CRM_Contact_Selector_Custom extends CRM_Core_Selector_Base implements CRM_Core_Selector_API {
+class CRM_Contact_Selector_Custom extends CRM_Contact_Selector {
 
   /**
    * This defines two actions- View and Edit.
@@ -115,14 +115,17 @@ class CRM_Contact_Selector_Custom extends CRM_Core_Selector_Base implements CRM_
    *
    * @return CRM_Contact_Selector
    * @access public
-   */ function __construct($customSearchClass,
+   */
+  function __construct(
+    $customSearchClass,
     $formValues        = NULL,
     $params            = NULL,
     $returnProperties  = NULL,
     $action            = CRM_Core_Action::NONE,
     $includeContactIds = FALSE,
     $searchChildGroups = TRUE,
-    $searchContext     = 'search'
+    $searchContext     = 'search',
+    $contextMenu       = NULL
   ) {
     $this->_customSearchClass = $customSearchClass;
     $this->_formValues = $formValues;
@@ -334,6 +337,9 @@ class CRM_Contact_Selector_Custom extends CRM_Core_Selector_Base implements CRM_
         $rows[] = $row;
       }
     }
+
+    $this->buildPrevNextCache($sort);
+
     return $rows;
   }
 


### PR DESCRIPTION
This might be best NOT in 4.2.10 as it brings forward a required change to custom custom searches (changing a function signature.) 

 However this can be an important patch in other circumstances as the patch fixes a problem where search results are only selectable on page one of search results.
