### PR TITLE
CRM-12036 - Do not delete extension files by default on uninstall

### DIFF
--- a/CRM/Core/Extensions.php
+++ b/CRM/Core/Extensions.php
@@ -654,7 +654,7 @@ class CRM_Core_Extensions {
    *
    * @return void
    */
-  public function uninstall($id, $key, $removeFiles = TRUE) {
+  public function uninstall($id, $key, $removeFiles = FALSE) {
     $this->populate();
     $e = $this->getExtensions();
     $ext = $e[$key];


### PR DESCRIPTION
Not really a backport of anything since the extensions framework has been reworked in 4.3 but implements the same behavior by not deleting extension files on uninstall.
