### PR TITLE
CRM-13397 js, contribution form - generalise  button double submit prote...

### DIFF
--- a/CRM/Contact/Form/Task/EmailCommon.php
+++ b/CRM/Contact/Form/Task/EmailCommon.php
@@ -271,6 +271,8 @@ class CRM_Contact_Form_Task_EmailCommon {
     }
 
     $form->addFormRule(array('CRM_Contact_Form_Task_EmailCommon', 'formRule'), $form);
+    CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'templates/CRM/Core/Form.js');
+    CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'templates/CRM/Contact/Form/Task/EmailCommon.js');
   }
 
   /**

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -474,7 +474,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
             'name' => $contribButton,
             'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
             'isDefault' => TRUE,
-            'js' => array('onclick' => "return submitOnce(this,'" . $this->_name . "','" . ts('Processing') . "');"),
           ),
           array(
             'type' => 'back',
@@ -539,6 +538,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $this->setDefaults($defaults);
 
     $this->freeze();
+
+    parent::buildQuickForm();
   }
 
   /**

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -607,6 +607,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     }
 
     $this->addFormRule(array('CRM_Contribute_Form_Contribution_Main', 'formRule'), $this);
+    parent::buildQuickForm();
   }
 
   /**

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -287,7 +287,14 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @return void
    *
    */
-  function buildQuickForm() {}
+  function buildQuickForm() {
+    // @todo less cautious approach would be to add this to addButtons.
+    // it would be good to make this switch at the early stage of a release cycle.
+    // @ the moment of the 106 uses of parent::buildQuickForm only a handle are direct descendents
+    // of this class - including the contribution forms per CRM-13397 & the (tested) sms provider form.
+    //(I checked maybe another 20 directly that weren't & was also able to rule out about 40 more by virtue of common patterns
+    CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'templates/CRM/Core/Form.js');
+  }
 
   /**
    * This virtual function is used to set the default values of
@@ -402,10 +409,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $js = CRM_Utils_Array::value('js', $button);
       $isDefault = CRM_Utils_Array::value('isDefault', $button, FALSE);
       if ($isDefault) {
-        $attrs = array('class' => 'form-submit default');
+        $attrs = array('class' => 'form-submit default crm-form-button-' . $button['type']);
       }
       else {
-        $attrs = array('class' => 'form-submit');
+        $attrs = array('class' => 'form-submit crm-form-button-' . $button['type']);
       }
 
       if ($js) {

--- a/templates/CRM/Contact/Form/Task/EmailCommon.js
+++ b/templates/CRM/Contact/Form/Task/EmailCommon.js
@@ -1,0 +1,4 @@
+cj(function ($) {
+  'use strict';
+  $().crmaccordions();
+});

--- a/templates/CRM/Core/Form.js
+++ b/templates/CRM/Core/Form.js
@@ -1,0 +1,8 @@
+cj(function ($) {
+    'use strict';
+    $('.form-submit').on("click", function() {
+      $('.form-submit').attr({value: ts('Processing'), disabled : 'disabled'});
+      $('.crm-form-button-back ').closest('span').hide();
+      $('.crm-form-button-cancel').closest('span').hide();
+    });
+});


### PR DESCRIPTION
...ction and add to contribution.main to prevent double submits where people have no confirm page

Conflicts:
    js/Common.js
    templates/CRM/Contact/Form/Task/EmailCommon.js

Conflicts:
    CRM/Contact/Form/Task/EmailCommon.php
    packages
    templates/CRM/Contact/Form/Task/EmailCommon.js
