### PR TITLE
Typo in LC_CTYPE

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -64,7 +64,7 @@ class CRM_Core_I18n {
         // CRM-11833 Avoid LC_ALL because of LC_NUMERIC and potential DB error.
         setlocale(LC_TIME, $locale);
         setlocale(LC_MESSAGES, $locale);
-        setlocale(LC_CTYPES, $locale);
+        setlocale(LC_CTYPE, $locale);
 
         bindtextdomain('civicrm', $config->gettextResourceDir);
         bind_textdomain_codeset('civicrm', 'UTF-8');


### PR DESCRIPTION
There is a typo in my last pull request about CRM-11833 / CRM-13043
cf. https://github.com/samuelsov/civicrm42-core/commit/0775c17b0a7801789828907bea6721c265771ce5
